### PR TITLE
Fix homepage reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "http-status",
   "version": "0.1.5",
   "description": "Interact with HTTP status code",
-  "homepage": "http://www.adaltas.com/projects/node-http-status.html",
+  "homepage": "http://www.adaltas.com/projects/node-http-status",
   "author": "David Worms <david@adaltas.com>",
   "keywords": ["http", "express", "connect"],
   "repository": {


### PR DESCRIPTION
The URL in package.json returns a 404 - seen on the npmjs.org page for the module.
