### PR TITLE
Use Math.pow for better compatibility

### DIFF
--- a/test/index.coffee
+++ b/test/index.coffee
@@ -6,7 +6,7 @@ nginx = require '../src/nginx'
 unofficial = require '../src/unofficial'
 
 getDigit = (ntn, number) ->
-  Math.floor number / 10 ** ntn % 10
+  Math.floor number / Math.pow(10, ntn) % 10
 
 describe 'HTTP Status Codes', ->
 


### PR DESCRIPTION
Saw that the [tests are failing](https://travis-ci.org/adaltas/node-http-status/jobs/595991697) because of the `**` operator for node `~6.0.0`.

Would it be possible to have Travis CI run on PR's also?