### PR TITLE
fix(types): improve TypeScript strict typing for numeric keys in HttpStatus

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,15 +4,6 @@ declare const httpStatus: httpStatus.HttpStatus;
 
 declare namespace httpStatus {
   interface HttpStatus {
-    readonly [key: number]: string | undefined;
-
-    readonly [key: string]:
-    | string
-    | number
-    | HttpStatusClasses
-    | HttpStatusExtra
-    | undefined;
-
     readonly 100: string;
     readonly '100_NAME': string;
     readonly '100_MESSAGE': string;
@@ -395,8 +386,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusClasses {
-    readonly [key: string]: string | number;
-
     readonly '1xx': string;
     readonly '1xx_NAME': string;
     readonly '1xx_MESSAGE': string;
@@ -424,8 +413,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusUnofficial {
-    readonly [key: string]: string | number;
-
     readonly 103: string;
     readonly '103_NAME': string;
     readonly '103_MESSAGE': string;
@@ -476,8 +463,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusIis {
-    readonly [key: string]: string | number;
-
     readonly 440: string;
     readonly '440_NAME': string;
     readonly '440_MESSAGE': string;
@@ -498,8 +483,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusNginx {
-    readonly [key: string]: string | number;
-
     readonly 444: string;
     readonly '444_NAME': string;
     readonly '444_MESSAGE': string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,15 +4,6 @@ declare const httpStatus: httpStatus.HttpStatus;
 
 declare namespace httpStatus {
   interface HttpStatus {
-    readonly [key: number]: string | undefined;
-
-    readonly [key: string]:
-    | string
-    | number
-    | HttpStatusClasses
-    | HttpStatusExtra
-    | undefined;
-
     readonly 100: string;
     readonly '100_NAME': string;
     readonly '100_MESSAGE': string;
@@ -395,8 +386,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusClasses {
-    readonly [key: string]: string | number;
-
     readonly '1xx': string;
     readonly '1xx_NAME': string;
     readonly '1xx_MESSAGE': string;
@@ -424,8 +413,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusUnofficial {
-    readonly [key: string]: string | number;
-
     readonly 103: string;
     readonly '103_NAME': string;
     readonly '103_MESSAGE': string;
@@ -476,8 +463,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusIis {
-    readonly [key: string]: string | number;
-
     readonly 440: string;
     readonly '440_NAME': string;
     readonly '440_MESSAGE': string;
@@ -498,8 +483,6 @@ declare namespace httpStatus {
   }
 
   interface HttpStatusNginx {
-    readonly [key: string]: string | number;
-
     readonly 444: string;
     readonly '444_NAME': string;
     readonly '444_MESSAGE': string;

--- a/test/types.ts
+++ b/test/types.ts
@@ -29,12 +29,12 @@ describe('Types', () => {
 
     it('undefined status codes', () => {
       const undefinedStatusCode = 777
-      const code: string = typeof status[undefinedStatusCode]
+      const code: string = typeof (status as any)[undefinedStatusCode]
       code.should.eql('undefined')
     })
 
     it('sub level properties', () => {
-      const number: number = status.extra.nginx.NO_RESPONSE
+      const number: 444 = status.extra.nginx.NO_RESPONSE
       const code: string = status.extra.nginx[number] as string
       code.should.eql('No Response')
       const name: string = status.extra.nginx[`${number}_NAME`] as string


### PR DESCRIPTION
The TypeScript type inference for numeric keys in the HttpStatus interface was previously unspecific, causing issues in strict typing scenarios. This fix removes unnecessary declarations, ensuring more accurate and strict TypeScript typing for numeric keys. It also includes updates to unit tests to reflect and validate the improved strict typing.

Closes #48