### PR TITLE
Expo app crashes when loading this package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
       "email": "daniel@gasienica.ch"
     }
   ],
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
Hi,
v2.0.0 can't be used with Expo projects, as Metro (its bundler) crashes without the `main` field being defined in `package.json`.